### PR TITLE
[names] Darken visited player nameplate text

### DIFF
--- a/better-name-colorizer/src/better-name-colorizer.js
+++ b/better-name-colorizer/src/better-name-colorizer.js
@@ -110,6 +110,24 @@ function addRules(css) {
     css.push("td.gp table.c a:visited:not([class^='con']) { color: #444 !important; }");
 }
 
+// Darken the nameplate text of players whose profiles have been visited.
+function clarifyNamePlates() {
+  if (document.getElementById('clarify-styles')) return;
+
+  const style = document.createElement('style');
+  style.id = 'clarify-styles';
+
+  style.textContent = `
+    html body table.c a:visited,
+    html body table.c a:visited span {
+      color: #444444 !important;
+      background-color: transparent !important;
+    }
+  `;
+
+  document.documentElement.appendChild(style);
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// INTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -137,3 +155,4 @@ function writeRules(css) {
 const cssRulesToAdd = [];
 addRules(cssRulesToAdd);
 writeRules(cssRulesToAdd);
+clarifyNamePlates();


### PR DESCRIPTION
Darkens the nameplate text of players whose profiles have been visited.

**Before:**
<img width="110" height="163" alt="before" src="https://github.com/user-attachments/assets/64baa53f-b5c2-4cfc-9737-359ab21a5482" />

**After:**
<img width="110" height="163" alt="after" src="https://github.com/user-attachments/assets/6b33e05e-45d0-4c1b-8ca8-4ee7ed6b572c" />
