### PR TITLE
Improve handling of null coordinates

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14784,7 +14784,9 @@ function updateGlobals() {
     return;
   }
 
-  [playerSX, playerSY] = suburbCoordsByName(suburbElem.textContent.trim() || "undefined") ?? [null, null];
+  playerSuburb = suburbElem.textContent.trim();
+
+  [playerSX, playerSY] = suburbCoordsByName(playerSuburb) ?? [null, null];
   [playerGX, playerGY] = globalPlayerCoords() ?? [null, null];
 }
 


### PR DESCRIPTION
Fixes errors caused by use of undefined player coordinates.

- Replaces `-1` with `null`
- Adds null guards to functions that consume player coordinates
