### PR TITLE
Fix alt highlights disappearing on clicked suburb

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14205,6 +14205,15 @@ function saveCurrentCharacterPosition() {
 }
 
 function drawAltMarkers() {
+  // clear existing alt highlights
+  for (let y = 0; y < 10; y++) {
+    for (let x = 0; x < 10; x++) {
+      const cell = cityMap.cells[y][x];
+      cell.classList.remove('map-alt-highlight');
+      cell.title = "";
+    }
+  }
+
   const chars = getStoredCharacters();
   const currentId = getCharacterId();
 
@@ -14217,9 +14226,7 @@ function drawAltMarkers() {
     const altCell = cityMap.cells[posAlt.sy]?.[posAlt.sx];
     if (!altCell) continue;
 
-    altCell.style.outline = "2px dashed #ffffff";
-    altCell.style.outlineOffset = "-1px";
-
+    altCell.classList.add('map-alt-highlight')
     altCell.title = posAlt.name || "Alt";
   }
 }
@@ -14694,6 +14701,7 @@ function setupCityInteractions() {
     }
 
     drawPlayerDot();
+    drawAltMarkers();
   }
 
   // ------------------------------------------------
@@ -14860,6 +14868,11 @@ function updateGlobals() {
         justify-content: center;
         text-align: center;
         box-sizing: border-box;
+      }
+
+      .map-alt-highlight {
+        outline: 2px dashed #ffffff !important;
+        outline-offset: -1px !important;
       }
     `;
     document.head.appendChild(style);


### PR DESCRIPTION
Fixes #14

The `drawSuburbMap` function was clearing all `outline` styles on the city map to handle the "active suburb" highlight. This inadvertently wiped the outlines used for alt markers since both features shared the same CSS property.

Fix:
- Move alt styling to a CSS class (`.map-alt-highlight`)
- Ensure `drawAltMarkers()` runs _after_ the city grid reset to reapply highlights