### PR TITLE
Refine suburb outlines to improve consistency

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14829,8 +14829,6 @@ function updateGlobals() {
       }
 
       .map-suburb-selected {
-        outline: 2px #FFF !important;
-        outline-offset: -1px !important;
         z-index: 20 !important;
         position: relative !important;
         box-shadow: 0 0 4px 1px rgba(0, 0, 0, 1), 0 0 8px 2px rgba(0, 0, 0, 0.9), 0 0 12px 4px rgba(5,255, 255, 0.8), 0 0 18px 6px rgba(255, 255, 255, 0.7), 0 0 24px 8px rgba(255, 255, 255, 0.6), inset 0 0 6px 2px rgba(89, 255, 27, 0.8), inset 0 0 10px 4px rgba(89, 255, 27, 0.5);


### PR DESCRIPTION
Refines suburb outlines to improve consistency and interpretability across character states and selections.

The current suburb borders and outlines are subtly inconsistent and occasionally misleading. For example:

1. The **selected** suburb currently uses the same dashed outline as suburbs containing an **alt** character.
2. Both the **current** suburb and **alt** suburbs indicate the presence of a character, but they use different visual styles.

Changes:

- Added an outline to the current suburb that matches the style used for alts.
- Swapped the outline on the selected suburb for a box shadow to prevent it from being mistaken for a character indicator.

Outcomes:

- Any suburb containing a character (primary or alt) now uses a unified dashed white outline.
- The currently selected suburb is now visually distinct from suburbs containing characters.
- The current character's suburb retains its black border for primary focus.
- It's now possible to visually verify at a glance whether an alt is present in the currently selected suburb.
