### PR TITLE
Add map indicators for alt characters

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14844,6 +14844,7 @@ function updateGlobals() {
         align-items: center;
         justify-content: center;
         text-align: center;
+        text-shadow: 2px 2px 4px rgba(0,0,0,1);
         box-sizing: border-box;
       }
 


### PR DESCRIPTION
Fixes #17 

Adds player dots for alt characters.

- Alt characters are now marked with ▲ on the suburb and local maps
- Adds text shadow to improve marker visibility on low-contrast tiles
- Centralizes player dot rendering logic into `drawPlayerDots()`

**Before:**
<img width="38" height="43" alt="image" src="https://github.com/user-attachments/assets/3afa5f53-8fcd-4b01-ba8b-a206591b49a1" />

**After:**
<img width="41" height="43" alt="image" src="https://github.com/user-attachments/assets/486ef043-2ad2-48af-a8a6-9358c9b4fe74" />
