### PR TITLE
Replace `GM` Storage with `localStorage` Wrapper

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -6,8 +6,6 @@
 // @description  Displays city and suburb map in WWDead
 // @include  /^https:\/\/wwdead\.com\/classic\/?(\?.*)?$/
 // @include  /^https:\/\/wwdead\.com\/classic\/stats\/?(\?.*)?$/
-// @grant        GM.setValue
-// @grant        GM.getValue
 // @license      GNU General Public License v2 or later; http://www.gnu.org/licenses/gpl.txt
 // @downloadURL https://greasyfork.org/en/scripts/567867-wwdead-tactical-map.user.js
 // @updateURL https://greasyfork.org/en/scripts/567867-wwdead-tactical.meta.js
@@ -14114,6 +14112,29 @@
 const STORAGE_KEY = "wwdead_chars_v2";
 const MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MAX_ALTS = 10;
+
+// drop-in replacement for GM.getValue and GM.setValue using localStorage
+const GM_KEY_PREFIX = "wwdead_map:gm:";
+const GM = {
+  getValue: async (key, defaultValue) => {
+    const value = localStorage.getItem(GM_KEY_PREFIX + key);
+    if (value === null) return defaultValue;
+
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  },
+
+  setValue: async (key, value) => {
+    localStorage.setItem(GM_KEY_PREFIX + key, JSON.stringify(value));
+  },
+
+  deleteValue: async (key) => {
+    localStorage.removeItem(GM_KEY_PREFIX + key);
+  }
+};
 
 function getProfileLink() {
   return document.querySelector('.gt a[href*="/classic/profile"]');


### PR DESCRIPTION
This PR replaces the Greasemonkey (`GM`) storage API with a `localStorage` wrapper. It maintains the original API as a drop-in replacement while improving data persistence and developer experience.

**Rationale:**
- `GM` storage is tied to specific plugin installations; data is often lost during uninstalls or reinstalls. `localStorage` persists across script updates and re-installations.
- `GM` storage is isolated from other scripts and browser tools, making debugging difficult, unlike `localStorage`.

**Changes:**
- Implements a mock `GM` object that mirrors the async `getValue`, `setValue`, and `deleteValue` API.
- Namespaces keys with a `wwdead_map:gm:` prefix to prevent collisions with other scripts.
- Removes `@grant` requirements for `GM.setValue` and `GM.getValue` from the userscript header.