### PR TITLE
Show no more than 1 OOB block at map edge

### DIFF
--- a/tactical-map/dist/TacticalMap.user.js
+++ b/tactical-map/dist/TacticalMap.user.js
@@ -14340,10 +14340,12 @@ function drawAltMarkers() {
     await createMapToggle(() => miniMap, "local", "Loc");
 
     // local map radius input
+    const MAX_RADIUS = 18;
+
     const radiusInput = document.createElement("input");
     radiusInput.type = "number";
     radiusInput.min = "1";
-    radiusInput.max = "12";
+    radiusInput.max = `${MAX_RADIUS}`;
     radiusInput.step = "1";
     radiusInput.value = LOCAL_MAP_RADIUS;
     radiusInput.style.cssText =
@@ -14354,7 +14356,7 @@ function drawAltMarkers() {
       let newRadius = parseInt(radiusInput.value);
       if (isNaN(newRadius)) return;
       if (newRadius < 1) newRadius = 1;
-      if (newRadius > 12) newRadius = 12;
+      if (newRadius > MAX_RADIUS) newRadius = MAX_RADIUS;
       radiusInput.value = newRadius;
 
       if (newRadius !== LOCAL_MAP_RADIUS) {


### PR DESCRIPTION
Shows no more than 1 block of out-of-bounds tiles at the edges of Malton (in the local map).

**Before:**
<img width="243" height="243" alt="image" src="https://github.com/user-attachments/assets/d6449646-ffa6-4c27-8f5c-1966167b4511" />

**After:**
<img width="244" height="244" alt="image" src="https://github.com/user-attachments/assets/4860380e-2ca8-4fcc-a79d-1d3772da279b" />