### PR TITLE
Show relative GPS offsets with diagonal pathing

### DIFF
--- a/tactical-map/dist/TacticalMap.user.js
+++ b/tactical-map/dist/TacticalMap.user.js
@@ -14912,13 +14912,29 @@ function updateGlobals() {
 
     if (dx === 0 && dy === 0) return " (Here)";
 
-    let xDir = dx > 0 ? "E" : "W";
-    let yDir = dy > 0 ? "S" : "N";
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
 
-    let xStr = dx !== 0 ? `${Math.abs(dx)}${xDir}` : "";
-    let yStr = dy !== 0 ? `${Math.abs(dy)}${yDir}` : "";
+    const xDir = dx > 0 ? "E" : "W";
+    const yDir = dy > 0 ? "S" : "N";
 
-    return ` [${[yStr, xStr].filter(Boolean).join(", ")}]`;
+    let result = [];
+
+    if (dx !== 0 && dy !== 0) {
+      const diagDist = Math.min(absX, absY);
+      result.push(`${diagDist}${yDir}${xDir}`);
+
+      if (absX > absY) {
+        result.push(`${absX - absY}${xDir}`);
+      } else if (absY > absX) {
+        result.push(`${absY - absX}${yDir}`);
+      }
+    } else {
+      if (dx !== 0) result.push(`${absX}${xDir}`);
+      if (dy !== 0) result.push(`${absY}${yDir}`);
+    }
+
+    return ` [${result.join(", ")}]`;
   }
 
   function addStyles() {


### PR DESCRIPTION
Adds relative cardinal offsets to the GPS display. When hovering over any tile in the local or suburb minimaps, the header now displays the exact distance and direction from the player's current position to the target tile. (i.e. `[2SE, 2E]`)

The logic calculates the most efficient path by prioritizing diagonal components and displaying any "leftover" cardinal steps.

Changes:
- New `getRelativeOffset` helper function to calculate distance between `playerGX/GY` and target coordinates.
- Diagonal pathing logic identifies the maximum shared diagonal distance, combining directions and adding remaining cardinal steps.
- Update `setupSuburbInteractions` and `setupLocalInteractions` to parse `dataset.gps` on `mouseenter`

<img width="232" height="266" alt="image" src="https://github.com/user-attachments/assets/753ce51d-1a90-48f7-8fa3-5eaf59eb7e78" />