### PR TITLE
Fix trimming [nt] with correct case (lowercase)

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -15382,7 +15382,7 @@
         .toLowerCase()
         .replace(/\b(the|a|an)\b/g, "")
         .replace(/\s+/g, " ")
-        .replace(/ \[NT\]$/, "")
+        .replace(/ \[nt\]$/, "")
         .trim();
     }
 


### PR DESCRIPTION
Fixes an unresolved GPS bug near NT buildings by correctly trimming ` [nt]` from names in lowercase, not uppercase.
