### PR TITLE
Use cached coordinates when globalPlayerCoords fails

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -15454,7 +15454,7 @@
 
     playerSuburb = suburbElem.textContent.trim();
     [playerSX, playerSY] = suburbCoordsByName(playerSuburb) ?? [null, null];
-    [playerGX, playerGY] = globalPlayerCoords() ?? [null, null];
+    [playerGX, playerGY] = globalPlayerCoords() ?? [playerGX, playerGY];
   }
 
   function updateMaps() {


### PR DESCRIPTION
This assigns a character's cached coordinates to playerGX/GY when `globalPlayerCoords` fails.

Currently, `playerGX` and `playerGY` become null if `globalPlayerCoords` returns null in `updateGlobal`. Instead, we should restore the character's cached coordinates.

This fixes an issue where the local map would become black at 0 AP (or death).

