### PR TITLE
Fix non-persisted settings and remove GM wrapper

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -37,6 +37,7 @@
   const CURRENT_MEM_VERSION = 2; // bump to wipe stored data
   const MEM_VERSION_KEY = "tacticalmap:memResetVersion";
   const COLLAPSED_KEY = "tacticalmap:collapsed";
+  const LOCAL_MAP_RADIUS_KEY = "tacticalmap:LOCAL_MAP_RADIUS";
 
   function checkMemoryVersion() {
     const storedVersion = parseInt(localStorage.getItem(MEM_VERSION_KEY) || "0", 10);
@@ -45,7 +46,7 @@
       // clear all tacticalmap storage
       localStorage.removeItem("tacticalmap:chars_v2");
       localStorage.removeItem("tacticalmap:settings");
-      localStorage.removeItem("LOCAL_MAP_RADIUS");
+      localStorage.removeItem(LOCAL_MAP_RADIUS_KEY);
       localStorage.removeItem(COLLAPSED_KEY);
       localStorage.setItem(MEM_VERSION_KEY, CURRENT_MEM_VERSION);
     }
@@ -55,10 +56,7 @@
   // -----------------------------
   // Local map settings
   // -----------------------------
-  let LOCAL_MAP_RADIUS = parseInt(
-      localStorage.getItem("tacticalmap:LOCAL_MAP_RADIUS") || 5,
-      10
-  );
+  let LOCAL_MAP_RADIUS = parseInt(localStorage.getItem(LOCAL_MAP_RADIUS_KEY) || 5, 10);
   let LOCAL_MAP_SIZE = LOCAL_MAP_RADIUS * 2 + 1;
 
   const MAIN_PLAYER_SYM = "●";
@@ -14955,7 +14953,7 @@
       if (newRadius !== LOCAL_MAP_RADIUS) {
         LOCAL_MAP_RADIUS = newRadius;
         LOCAL_MAP_SIZE = LOCAL_MAP_RADIUS * 2 + 1;
-        localStorage.setItem("LOCAL_MAP_RADIUS", LOCAL_MAP_RADIUS);
+        localStorage.setItem(LOCAL_MAP_RADIUS_KEY, LOCAL_MAP_RADIUS);
         // recreate minimap
         const oldWrap = miniMap.wrap;
         const currentDisplay = oldWrap.style.display;

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -35,6 +35,7 @@
   // MEMORY VERSIONING
   // ------------------------------------------------
   const CURRENT_MEM_VERSION = 2; // bump to wipe stored data
+  const CHARACTERS_KEY = "tacticalmap:chars_v2";
   const MEM_VERSION_KEY = "tacticalmap:memResetVersion";
   const COLLAPSED_KEY = "tacticalmap:collapsed";
   const LOCAL_MAP_RADIUS_KEY = "tacticalmap:LOCAL_MAP_RADIUS";
@@ -44,7 +45,7 @@
     if (storedVersion < CURRENT_MEM_VERSION) {
       console.log(`Memory reset triggered: stored=${storedVersion}, current=${CURRENT_MEM_VERSION}`);
       // clear all tacticalmap storage
-      localStorage.removeItem("tacticalmap:chars_v2");
+      localStorage.removeItem(CHARACTERS_KEY);
       localStorage.removeItem("tacticalmap:settings");
       localStorage.removeItem(LOCAL_MAP_RADIUS_KEY);
       localStorage.removeItem(COLLAPSED_KEY);
@@ -14708,7 +14709,6 @@
   // ALT MARKERS STORAGE (FINAL VERSION)
   // ------------------------------------------------
 
-  const STORAGE_KEY = "tacticalmap:chars_v2";
   const MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
   const MAX_ALTS = 10;
 
@@ -14732,14 +14732,14 @@
 
   function getStoredCharacters() {
     try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+      return JSON.parse(localStorage.getItem(CHARACTERS_KEY) || "{}");
     } catch {
       return {};
     }
   }
 
   function saveStoredCharacters(chars) {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(chars));
+    localStorage.setItem(CHARACTERS_KEY, JSON.stringify(chars));
   }
 
   function cleanupOldCharacters(chars) {
@@ -14969,7 +14969,7 @@
     clearBtn.onclick = () => {
       if (!confirm("Clear all stored alt positions?")) return;
 
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(CHARACTERS_KEY);
       console.log("🧹 Cleared alt storage");
 
       updateMaps();

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14712,29 +14712,6 @@
   const MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
   const MAX_ALTS = 10;
 
-  // drop-in replacement for GM.getValue and GM.setValue using localStorage
-  const GM_KEY_PREFIX = "tacticalmap:gm:";
-  const GM = {
-    getValue: async (key, defaultValue) => {
-      const value = localStorage.getItem(GM_KEY_PREFIX + key);
-      if (value === null) return defaultValue;
-
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
-    },
-
-    setValue: async (key, value) => {
-      localStorage.setItem(GM_KEY_PREFIX + key, JSON.stringify(value));
-    },
-
-    deleteValue: async (key) => {
-      localStorage.removeItem(GM_KEY_PREFIX + key);
-    },
-  };
-
   function getProfileLink() {
     return document.querySelector('.gt a[href*="/classic/profile"]');
   }

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -28,7 +28,7 @@
  * http://www.gnu.org/licenses/gpl.txt
  */
 
-(async function () {
+(function () {
   "use strict";
 
   // ------------------------------------------------
@@ -14826,7 +14826,7 @@
   // CREATE MAP WINDOW (Collapsible)
   // ------------------------------------------------
 
-  async function createMainContainer() {
+  function createMainContainer() {
     let collapsed = false;
 
     const container = document.createElement("div");
@@ -14879,7 +14879,7 @@
     cityMap.coords.textContent = `Selected: ${selectedSuburb || playerSuburb}`;
 
     // helper to create toggle checkboxes
-    const createMapToggle = async (getMap, key, labelText) => {
+    const createMapToggle = (getMap, key, labelText) => {
       const label = document.createElement("label");
       label.style.cssText =
         "display:flex; align-items:center; gap:2px; cursor:pointer;";
@@ -14894,7 +14894,7 @@
       cb.checked = isVisible;
       getMap().wrap.style.display = isVisible ? "flex" : "none";
 
-      cb.onchange = async () => {
+      cb.onchange = () => {
         getMap().wrap.style.display = cb.checked ? "flex" : "none";
         localStorage.setItem(MAP_VISIBLE_KEY, cb.checked);
       };
@@ -14905,9 +14905,9 @@
     };
 
     // add checkboxes to upper right
-    await createMapToggle(() => cityMap, "city", "City");
-    await createMapToggle(() => suburbMap, "suburb", "Sub");
-    await createMapToggle(() => miniMap, "local", "Loc");
+    createMapToggle(() => cityMap, "city", "City");
+    createMapToggle(() => suburbMap, "suburb", "Sub");
+    createMapToggle(() => miniMap, "local", "Loc");
 
     // local map radius input
     const MAX_RADIUS = 18;
@@ -15610,14 +15610,14 @@
   // START SCRIPT
   // ------------------------------------------------
 
-  window.addEventListener("load", async () => {
+  window.addEventListener("load", () => {
     addStyles();
     updateGlobals();
 
     // SAVE AFTER globals are ready
     saveCurrentCharacterPosition();
 
-    await createMainContainer();
+    createMainContainer();
 
     setupCityInteractions();
     setupSuburbInteractions();

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -36,6 +36,7 @@
   // ------------------------------------------------
   const CURRENT_MEM_VERSION = 2; // bump to wipe stored data
   const MEM_VERSION_KEY = "tacticalmap:memResetVersion";
+  const COLLAPSED_KEY = "tacticalmap:collapsed";
 
   function checkMemoryVersion() {
     const storedVersion = parseInt(localStorage.getItem(MEM_VERSION_KEY) || "0", 10);
@@ -14882,7 +14883,7 @@
       mapHolder.style.display = collapsed ? "none" : "flex";
       controls.style.display = collapsed ? "none" : "flex"; // Hide checkboxes when main is collapsed
       mainToggleBtn.textContent = collapsed ? "[+]" : "[-]";
-      await GM.setValue("collapsed", collapsed);
+      localStorage.setItem(COLLAPSED_KEY, collapsed);
     }
 
     mainToggleBtn.onclick = async () => await setCollapsed(!collapsed);
@@ -15001,7 +15002,7 @@
     mapHolder.appendChild(suburbMap.wrap);
     mapHolder.appendChild(miniMap.wrap);
 
-    await setCollapsed((await GM.getValue("collapsed")) ?? false);
+    await setCollapsed(localStorage.getItem(COLLAPSED_KEY) === "true");
   }
 
   // ------------------------------------------------

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14911,13 +14911,15 @@
       cb.type = "checkbox";
       cb.style.margin = "0";
 
-      let isVisible = await GM.getValue(`map_visible_${key}`, true);
+      const MAP_VISIBLE_KEY = `tacticalmap:map_visible:${key}`;
+
+      let isVisible = (localStorage.getItem(MAP_VISIBLE_KEY) || "true") === "true";
       cb.checked = isVisible;
       getMap().wrap.style.display = isVisible ? "flex" : "none";
 
       cb.onchange = async () => {
         getMap().wrap.style.display = cb.checked ? "flex" : "none";
-        await GM.setValue(`map_visible_${key}`, cb.checked);
+        localStorage.setItem(MAP_VISIBLE_KEY, cb.checked);
       };
 
       label.appendChild(cb);

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14853,7 +14853,7 @@
     topBar.appendChild(mainToggleBtn);
     container.appendChild(topBar);
 
-    async function setCollapsed(value) {
+    function setCollapsed(value) {
       collapsed = value;
       container.style.display = "flex";
       mapHolder.style.display = collapsed ? "none" : "flex";
@@ -14862,7 +14862,7 @@
       localStorage.setItem(COLLAPSED_KEY, collapsed);
     }
 
-    mainToggleBtn.onclick = async () => await setCollapsed(!collapsed);
+    mainToggleBtn.onclick = () => setCollapsed(!collapsed);
 
     const mapHolder = document.createElement("div");
     mapHolder.style.cssText = "display:flex;gap:10px;align-items:flex-start";
@@ -14980,7 +14980,7 @@
     mapHolder.appendChild(suburbMap.wrap);
     mapHolder.appendChild(miniMap.wrap);
 
-    await setCollapsed(localStorage.getItem(COLLAPSED_KEY) === "true");
+    setCollapsed(localStorage.getItem(COLLAPSED_KEY) === "true");
   }
 
   // ------------------------------------------------

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -14870,9 +14870,9 @@
     document.body.appendChild(container);
 
     // create maps
-    cityMap = await makeMap("City Map", 10, "city");
-    suburbMap = await makeMap("Suburb Map", 10, "suburb");
-    miniMap = await makeMap("Local", LOCAL_MAP_SIZE, "local");
+    cityMap = makeMap("City Map", 10, "city");
+    suburbMap = makeMap("Suburb Map", 10, "suburb");
+    miniMap = makeMap("Local", LOCAL_MAP_SIZE, "local");
 
     // override initial labels
     miniMap.label.textContent = `Local (${playerSuburb})`;
@@ -14922,7 +14922,7 @@
       "width:32px; background:#223322; color:#BBCCBB; border:1px solid #445544; font-size:10px; margin-left:2px; height: 14px; padding: 0 2px;";
     radiusInput.title = "Local Map Radius (size = 2R + 1)";
 
-    radiusInput.onchange = async () => {
+    radiusInput.onchange = () => {
       let newRadius = parseInt(radiusInput.value);
       if (isNaN(newRadius)) return;
       if (newRadius < 1) newRadius = 1;
@@ -14936,7 +14936,7 @@
         // recreate minimap
         const oldWrap = miniMap.wrap;
         const currentDisplay = oldWrap.style.display;
-        miniMap = await makeMap("Local", LOCAL_MAP_SIZE, "local");
+        miniMap = makeMap("Local", LOCAL_MAP_SIZE, "local");
         miniMap.wrap.style.display = currentDisplay;
         oldWrap.parentNode.replaceChild(miniMap.wrap, oldWrap);
 
@@ -14987,7 +14987,7 @@
   // MAP BUILDER
   // ------------------------------------------------
 
-  async function makeMap(title, size = 10, key) {
+  function makeMap(title, size = 10, key) {
     const wrap = document.createElement("div");
     wrap.style.width = size * 22 + "px";
     wrap.style.display = "flex";

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -46,7 +46,6 @@
       console.log(`Memory reset triggered: stored=${storedVersion}, current=${CURRENT_MEM_VERSION}`);
       // clear all tacticalmap storage
       localStorage.removeItem(CHARACTERS_KEY);
-      localStorage.removeItem("tacticalmap:settings");
       localStorage.removeItem(LOCAL_MAP_RADIUS_KEY);
       localStorage.removeItem(COLLAPSED_KEY);
       localStorage.setItem(MEM_VERSION_KEY, CURRENT_MEM_VERSION);

--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -46,6 +46,7 @@
       localStorage.removeItem("tacticalmap:chars_v2");
       localStorage.removeItem("tacticalmap:settings");
       localStorage.removeItem("LOCAL_MAP_RADIUS");
+      localStorage.removeItem(COLLAPSED_KEY);
       localStorage.setItem(MEM_VERSION_KEY, CURRENT_MEM_VERSION);
     }
   }


### PR DESCRIPTION
Fixes `LOCAL_MAP_RADIUS` not being persisted and cleans up general use of `localStorage`.

- Introduces named constants for these `localStorage` keys to avoid potential typos.
- Replaces original `GM` storage wrapper with `localStorage`.
- Removes unnecessary `async` definitions, since `GM` is no longer used.
