### PR TITLE
Fix GPS coordinate parsing when player has multiple GPS'

### DIFF
--- a/tactical-map/src/TacticalMap.user.js
+++ b/tactical-map/src/TacticalMap.user.js
@@ -15347,12 +15347,12 @@
     // if GPS exists, directly parse coordinates and return
     const element = document.querySelector('input[value*="GPS unit"]');
     if (element) {
-      const matches = element.value.match(/\d+/g);
-      if (matches && matches.length >= 2) {
-        return [Number(matches[0]), Number(matches[1])];
-      } else {
-        console.error("Found GPS but no coordinates?");
+      const match = element.value.match(/\[(.*?)\]/);
+      const coords = match[1].split(',').map(num => Number(num.trim()));
+      if (coords.length == 2) {
+        return coords;
       }
+      console.error("Unexpected GPS format: "  + element.value);
     }
 
     // otherwise, find an exact match of neighboring tiles


### PR DESCRIPTION
Fixes GPS coordinate parsing when the player has more than one GPS.

When a player has two (or more) GPS', the item text becomes `GPS Unit (2) [46, 22]` which breaks the current parsing logic.
